### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
       - id: mypy
         additional_dependencies: [types-requests==2.31.0.1]
         args: [--follow-imports=skip]
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    - id: codespell

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ MicroJSON is compatible with any application or tool that process JSON data. Its
 
 ## Examples
 
-Refer to the examples foler to see samples of MicroJSON files as well as a simple parsing example, or the [example in the documentation](docs/example.md)
+Refer to the examples folder to see samples of MicroJSON files as well as a simple parsing example, or the [example in the documentation](docs/example.md)
 
 ## Specification
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ A feature object represents a spatially bounded entity associated with propertie
 - `"geometry"`: A geometry object as defined in the section above or a JSON null value.
 - `"properties"`: (Optional) A JSON object containing properties and metadata specific to the feature, or a JSON null value. It consists of key-value pairs, where the key is a string and the value is a any JSON value. The value may be a string, number, array, object.
 - `"id"`: (Optional) A unique identifier for this feature.
-- `"ref"`: (Optional) A reference to an external resource, e.g. URI to a zarr strcture, e.g. "s3://zarr-demo/store/my_array.zarr".
+- `"ref"`: (Optional) A reference to an external resource, e.g. URI to a zarr structure, e.g. "s3://zarr-demo/store/my_array.zarr".
 - `"parentId"`: (Optional) A reference to the parent feature, e.g. the id of the feature that this feature is a part of.
 - `"feeatureClass"`: (Optional) A string indicating the class of the feature, e.g. "cell", "nucleus", "mitochondria", etc.
 

--- a/docs/ome.md
+++ b/docs/ome.md
@@ -33,7 +33,7 @@ While TileJSON has traditionally been used in 2D applications, there is nothing 
 2. Associate NGFF array chunks with tile indices (z/x/y) derived from spatial transformations, given the NGFF multiscale metadata and the corresponding TileJSON metadata.
 3. A practical observation is that if the multiscale pyramids differs, transformations between the two systems are needed, in addition to what is described above, which could be avoided by using the same multiscale pyramid structure in both systems. This is also valid for the tile size (expressed in the global coordinates), which should be the same in both systems for a specific zoom level.
 4. Layering of data is supported in TileJSON, as the array `vector_layers` in its schema. Layers are thus stored together for each tile, as a contrast to the NGFF, where the layers are stored in separate arrays as labeled images.
-5. The NGFF raster data hierarchy could be expressed with a TileJSON which does not have a vector layer but intead just maps the raster data endpoints as formatted in the field `tiles` in the TileJSON schema.
+5. The NGFF raster data hierarchy could be expressed with a TileJSON which does not have a vector layer but instead just maps the raster data endpoints as formatted in the field `tiles` in the TileJSON schema.
 
 ## Incorporating MicroJSON and Vector Tiles
 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -21,7 +21,7 @@ The provenance model structure comprises `WorkflowCollection`, `Workflow`, `Arti
 - **Workflow Object:** Captures essential workflow details, including identifiers and descriptive metadata. This metadata links MicroJSON objects to their respective workflows.
 - **Artifact and Artifact Collection Objects:** Represent single files or directories and collections of these, respectively, providing a link between the physical data and the workflows.
 - **Workflow Provenance Object:** Details specific instances of workflow runs, including run identifiers, duration, operator, and the input/output parameters.
-Of these, Workflow, WorkflowCollection, Artifact, and ArtifactCollection can funtion as the top object in the provenance part of a MicroJSON file.
+Of these, Workflow, WorkflowCollection, Artifact, and ArtifactCollection can function as the top object in the provenance part of a MicroJSON file.
 - **MicroJSON Link Object:** Provides a link to a specific MicroJSON object, specifying which parts of the object's properties are pertinent to the workflow run. While this object is required, and the id property is required, the specification of a field in the MicroJSON object is optional. If no field is specified, the entire MicroJSON object is considered to be pertinent to the workflow run or artifact.
 
 ## Data Provenance and MicroJSON Traceability Link

--- a/microjson.d.ts
+++ b/microjson.d.ts
@@ -247,7 +247,7 @@ export interface MicroFeatureCollection {
   coordinateSystem?: CoordinateSystem | null;
   valueRange?: ValueRange;
   descriptive_fields?: DescriptiveFields;
-  propertie?: Properties | null;
+  property?: Properties | null;
   [k: string]: unknown;
 }
 /**

--- a/microjson_schema.json
+++ b/microjson_schema.json
@@ -469,7 +469,7 @@
                     "default": null,
                     "title": "Descriptive Fields"
                 },
-                "propertie": {
+                "property": {
                     "anyOf": [
                         {
                             "$ref": "#/$defs/Properties"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,10 @@ push            = false
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
 "src/microjson/__init__.py" = ["{version}"]
 ".bumpversion.cfg" = ["current_version = {version}"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ push            = false
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*'
+skip = '.git*,invalid'
 check-hidden = true
 ignore-regex = '^\s*"image/\S+": ".*'
 # ignore-words-list = ''

--- a/src/microjson/utils.py
+++ b/src/microjson/utils.py
@@ -206,7 +206,7 @@ class OmeMicrojsonModel:
         x: int,
         y: int,
     ) -> tuple[Any, list[list[list[Any]]]]:
-        """Calculate object boundries as series of vertices/points
+        """Calculate object boundaries as series of vertices/points
         forming a polygon."""
         label, coordinates = [], []
         objects = ndimage.measurements.find_objects(label_image)


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

TODOs
- [ ] see if `propertie` in the schema is on purpose and potentially drop that fix